### PR TITLE
Nameless buffers cause an error. Fixed.

### DIFF
--- a/plugin/activity-log.vim
+++ b/plugin/activity-log.vim
@@ -77,6 +77,9 @@ function s:LogAction(action)
 	endif
 
 	let l:file = expand("%:p")
+	if empty(l:file)
+		return
+	endif
 	let l:time = strftime('%F %T')
 
 	if a:action != "write"


### PR DESCRIPTION
You can't save them without naming them, so skip recording them.
